### PR TITLE
Update dependencies and util

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 spglib==2.0.2
 numpy==1.24.3
 scipy==1.9.3
-pymatgen==2023.9.2
+pymatgen<=2023.12.18
 inflect==6.0.4
 networkx==3.0
-matminer==0.8.0
-monty==2023.11.3
+matminer==0.9.1
+monty==2024.2.26
 pubchempy==1.0.4
 pybtex==0.24.0
-mp_api==0.34.0
+mp_api==0.41.2
 boto3

--- a/robocrys/condense/mineral.py
+++ b/robocrys/condense/mineral.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import numpy as np
 from matminer.utils.io import load_dataframe_from_json
-from pkg_resources import resource_filename
+from importlib.resources import files as import_resource_file
 from pymatgen.analysis.prototypes import AflowPrototypeMatcher
 from pymatgen.core.structure import IStructure
 
@@ -50,7 +50,7 @@ class MineralMatcher:
         use_fingerprint_matching: bool = True,
         fingerprint_distance_cutoff: float = 0.4,
     ):
-        db_file = resource_filename("robocrys.condense", "mineral_db.json.gz")
+        db_file = import_resource_file("robocrys.condense") / "mineral_db.json.gz"
         self.mineral_db = load_dataframe_from_json(db_file)
         self.initial_ltol = initial_ltol
         self.initial_stol = initial_stol

--- a/robocrys/condense/molecule.py
+++ b/robocrys/condense/molecule.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import warnings
 
 from monty.serialization import loadfn
-from pkg_resources import resource_filename
+from importlib.resources import files as import_resource_file
 from pubchempy import BadRequestError, get_compounds
 from pymatgen.analysis.graphs import MoleculeGraph
 from pymatgen.io.babel import BabelMolAdaptor
@@ -34,7 +34,7 @@ class MoleculeNamer:
                 used. Should be provided as a tuple of options, from 1st choice
                 to last.
         """
-        db_file = resource_filename("robocrys.condense", "molecule_db.json.gz")
+        db_file = import_resource_file("robocrys.condense") / "molecule_db.json.gz"
         self.molecule_db = loadfn(db_file)
         self.matched_molecules = {}
         self.use_online_pubchem = use_online_pubchem

--- a/robocrys/util.py
+++ b/robocrys/util.py
@@ -19,12 +19,12 @@ from typing import Any
 
 from monty.json import MontyDecoder
 from monty.serialization import loadfn
-from pkg_resources import resource_filename
+from importlib.resources import files as import_resource_file
 from pymatgen.core.periodic_table import Element, Species, get_el_sp
 from pymatgen.util.string import latexify_spacegroup
 
 common_formulas: dict[str, str] = loadfn(
-    resource_filename("robocrys.condense", "formula_db.json.gz")
+    import_resource_file("robocrys.condense") / "formula_db.json.gz"
 )
 
 connected_geometries: list[str] = [
@@ -285,9 +285,10 @@ def load_condensed_structure_json(filename: str) -> dict[str, Any]:
 
     # JSON does not support using integers a dictionary keys, therefore
     # manually convert dictionary keys from str to int if possible.
-    def json_keys_to_int(x):
-        if isinstance(x, dict):
-            return {int(k) if k.isdigit() else k: v for k, v in x.items()}
-        return None
-
-    return loadfn(filename, cls=MontyDecoder, object_hook=json_keys_to_int)
+    def json_keys_to_int(x : Any) -> Any:
+        if isinstance(x,dict):
+            return {int(k) if k.isdigit() else k: json_keys_to_int(v) for k, v in x.items()}
+        return x
+    # For some reason, specifying `object_hook = json_keys_to_int` in `loadfn`
+    # doesn't seem to work. This does reliably:
+    return json_keys_to_int(loadfn(filename, cls=MontyDecoder))

--- a/setup.py
+++ b/setup.py
@@ -46,14 +46,15 @@ setup(
         "spglib",
         "numpy",
         "scipy",
-        "pymatgen>=2020.10.20",
+        "pymatgen<=2023.12.18",
         "inflect",
         "networkx",
-        "matminer",
-        "monty",
+        "matminer==0.9.1",
+        "monty==2024.2.26",
         "pubchempy",
         "pybtex",
         "ruamel.yaml",
+        "mp_api==0.41.2"
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
Updating the dependencies for stability (some [issues with matminer that were recently fixed in a release](https://github.com/hackingmaterials/matminer/releases/tag/v0.9.1)), and changed how `util.load_condensed_structure_json` converts dict keys to ints when appropriate

Seems like the `object_hook` wasn't actually being called, despite being passed to `json.loads` through monty's `loadfn`